### PR TITLE
Publish to PyPI and GitHub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+# ref: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Publish Package
+
+on:
+  # publish from the Releases page:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish Package
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-python@v3
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build
+      run: python -m build
+
+    - name: Publish to Github
+      uses: softprops/action-gh-release@v1
+      with:
+        files: 'dist/*'
+        fail_on_unmatched_files: true
+        prerelease: ${{ contains(github.ref, 'rc') || contains(github.ref, 'dev') }}
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for InfCloud to work properly. Otherwise the "Refresh" button is broken.
 ## Installation
 
 ```shell
-python3 -m pip install --upgrade RadicaleInfCloud
+python3 -m pip install --upgrade radicale_infcloud
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for InfCloud to work properly. Otherwise the "Refresh" button is broken.
 ## Installation
 
 ```shell
-python3 -m pip install --upgrade https://github.com/Unrud/RadicaleInfCloud/archive/master.tar.gz
+python3 -m pip install --upgrade RadicaleInfCloud
 ```
 
 ## Configuration

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     description="InfCloud for Radicale",
     author="Unrud",
     author_email="unrud@outlook.com",
-    url="http://github.com/Unrud/RadicaleWeb",
+    url="https://github.com/Unrud/RadicaleInfCloud",
     license="GNU AGPL v3",
     platforms="Any",
     packages=["radicale_infcloud"],


### PR DESCRIPTION
As in https://github.com/Unrud/RadicaleIMAP/pull/8, I'd like to see this on PyPI for better visibility and to make it easier to pull it into my config management system. This script makes it easy and reliable to get releases posted, just by filling out [a form on GitHub's UI](https://github.com/Unrud/RadicaleInfCloud/releases/new).