### PR TITLE
Fix for Radicale >= 3.2.0

### DIFF
--- a/radicale_infcloud/__init__.py
+++ b/radicale_infcloud/__init__.py
@@ -17,6 +17,7 @@
 from http import client
 from radicale import httputils
 from radicale.web import internal
+from importlib.metadata import version
 
 PLUGIN_CONFIG_SCHEMA = {"web": {
     "infcloud_config": {
@@ -38,7 +39,12 @@ class Web(internal.Web):
             status, headers, answer = super().get(
                 environ, base_prefix, path, user)
         if status == client.OK and path in ("/.web/", "/.web/index.html"):
-            answer = answer.replace(b"""\
+            if version("radicale") >="3.2.0":
+                answer = answer.replace(b"""title="Refresh">Refresh</a>""",
+                                        b"""title="Refresh">Refresh</a>
+      <a class="blue" data-name="infcloud" title="InfCloud" style="float: left;left: 40px;" href="infcloud">InfCloud</a>""")
+            else:
+                answer = answer.replace(b"""\
 <nav>
     <ul>""", b"""\
 <nav>

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup
 
-VERSION = "3.1.6"
+VERSION = "3.2.2"
 
 package_path = os.path.join(os.path.dirname(__file__), "radicale_infcloud")
 web_data = sum((


### PR DESCRIPTION
Radicale 3.2.0 changed the web interface, so InfCloud won't work anymore. This makes InfCloud compatible with Radicale >= 3.2.0

This would fix #26.